### PR TITLE
exclude security_txt from no-entrypoint builds

### DIFF
--- a/programs/rate-mock/src/lib.rs
+++ b/programs/rate-mock/src/lib.rs
@@ -7,6 +7,7 @@ use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 
+#[cfg(not(feature = "no-entrypoint"))]
 solana_security_txt::security_txt! {
     name: "Rate Mock | Vyper Core",
     project_url: "https://vyperprotocol.io",

--- a/programs/rate-poolv2/src/lib.rs
+++ b/programs/rate-poolv2/src/lib.rs
@@ -8,6 +8,7 @@ use anchor_lang::prelude::*;
 use anchor_spl::token::{Mint, TokenAccount};
 use rust_decimal::Decimal;
 
+#[cfg(not(feature = "no-entrypoint"))]
 solana_security_txt::security_txt! {
     name: "Rate Poolv2 | Vyper Core",
     project_url: "https://vyperprotocol.io",

--- a/programs/rate-pyth/src/lib.rs
+++ b/programs/rate-pyth/src/lib.rs
@@ -7,6 +7,7 @@ use pyth_sdk_solana::{load_price_feed_from_account_info, Price, PriceFeed};
 use rust_decimal::{Decimal, MathematicalOps};
 use rust_decimal_macros::dec;
 
+#[cfg(not(feature = "no-entrypoint"))]
 solana_security_txt::security_txt! {
     name: "Rate Pyth | Vyper Core",
     project_url: "https://vyperprotocol.io",

--- a/programs/rate-switchboard/src/lib.rs
+++ b/programs/rate-switchboard/src/lib.rs
@@ -6,6 +6,7 @@ use anchor_lang::prelude::*;
 use rust_decimal::{prelude::FromPrimitive, Decimal};
 use switchboard_v2::{AggregatorAccountData, SWITCHBOARD_V2_DEVNET, SWITCHBOARD_V2_MAINNET};
 
+#[cfg(not(feature = "no-entrypoint"))]
 solana_security_txt::security_txt! {
     name: "Rate Switchboard | Vyper Core",
     project_url: "https://vyperprotocol.io",

--- a/programs/rate-twap/src/lib.rs
+++ b/programs/rate-twap/src/lib.rs
@@ -5,6 +5,7 @@ pub mod state;
 use anchor_lang::prelude::*;
 use instructions::*;
 
+#[cfg(not(feature = "no-entrypoint"))]
 solana_security_txt::security_txt! {
     name: "Rate TWAP | Vyper Core",
     project_url: "https://vyperprotocol.io",

--- a/programs/redeem-logic-digital/src/lib.rs
+++ b/programs/redeem-logic-digital/src/lib.rs
@@ -10,6 +10,7 @@ use anchor_lang::prelude::*;
 use rust_decimal::prelude::*;
 use vyper_utils::redeem_logic_common::RedeemLogicErrors;
 
+#[cfg(not(feature = "no-entrypoint"))]
 solana_security_txt::security_txt! {
     name: "Redeem Logic Digital | Vyper Core",
     project_url: "https://vyperprotocol.io",

--- a/programs/redeem-logic-farming/src/lib.rs
+++ b/programs/redeem-logic-farming/src/lib.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 use rust_decimal::prelude::*;
 use vyper_utils::redeem_logic_common::RedeemLogicErrors;
 
+#[cfg(not(feature = "no-entrypoint"))]
 solana_security_txt::security_txt! {
     name: "Redeem Logic Farming | Vyper Core",
     project_url: "https://vyperprotocol.io",

--- a/programs/redeem-logic-fila/src/lib.rs
+++ b/programs/redeem-logic-fila/src/lib.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 use rust_decimal::prelude::*;
 use vyper_utils::redeem_logic_common::RedeemLogicErrors;
 
+#[cfg(not(feature = "no-entrypoint"))]
 solana_security_txt::security_txt! {
     name: "Redeem Logic Fila | Vyper Core",
     project_url: "https://vyperprotocol.io",

--- a/programs/redeem-logic-forward/src/lib.rs
+++ b/programs/redeem-logic-forward/src/lib.rs
@@ -11,6 +11,7 @@ use anchor_lang::prelude::*;
 use rust_decimal::prelude::*;
 use vyper_utils::redeem_logic_common::RedeemLogicErrors;
 
+#[cfg(not(feature = "no-entrypoint"))]
 solana_security_txt::security_txt! {
     name: "Redeem Logic Forward | Vyper Core",
     project_url: "https://vyperprotocol.io",

--- a/programs/redeem-logic-lending-fee/src/lib.rs
+++ b/programs/redeem-logic-lending-fee/src/lib.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 use rust_decimal::prelude::*;
 use vyper_utils::redeem_logic_common::RedeemLogicErrors;
 
+#[cfg(not(feature = "no-entrypoint"))]
 solana_security_txt::security_txt! {
     name: "Redeem Logic Lending Fee | Vyper Core",
     project_url: "https://vyperprotocol.io",

--- a/programs/redeem-logic-lending/src/lib.rs
+++ b/programs/redeem-logic-lending/src/lib.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 use rust_decimal::prelude::*;
 use vyper_utils::redeem_logic_common::RedeemLogicErrors;
 
+#[cfg(not(feature = "no-entrypoint"))]
 solana_security_txt::security_txt! {
     name: "Redeem Logic Lending | Vyper Core",
     project_url: "https://vyperprotocol.io",

--- a/programs/redeem-logic-settled-forward/src/lib.rs
+++ b/programs/redeem-logic-settled-forward/src/lib.rs
@@ -14,6 +14,7 @@ use anchor_lang::prelude::*;
 use rust_decimal::prelude::*;
 use vyper_utils::redeem_logic_common::RedeemLogicErrors;
 
+#[cfg(not(feature = "no-entrypoint"))]
 solana_security_txt::security_txt! {
     name: "Redeem Logic Settled Forward | Vyper Core",
     project_url: "https://vyperprotocol.io",

--- a/programs/redeem-logic-vanilla-option/src/lib.rs
+++ b/programs/redeem-logic-vanilla-option/src/lib.rs
@@ -12,6 +12,7 @@ use anchor_lang::prelude::*;
 use rust_decimal::prelude::*;
 use vyper_utils::redeem_logic_common::RedeemLogicErrors;
 
+#[cfg(not(feature = "no-entrypoint"))]
 solana_security_txt::security_txt! {
     name: "Redeem Logic Vanilla Option | Vyper Core",
     project_url: "https://vyperprotocol.io",

--- a/programs/vyper-core/src/lib.rs
+++ b/programs/vyper-core/src/lib.rs
@@ -7,6 +7,7 @@ use anchor_lang::prelude::*;
 use instructions::*;
 use vyper_macros::*;
 
+#[cfg(not(feature = "no-entrypoint"))]
 solana_security_txt::security_txt! {
     name: "Vyper Core",
     project_url: "https://vyperprotocol.io",


### PR DESCRIPTION
The usage of `solana-security-txt` previously recommended in the official usage guide has an issue:

When multiple projects within a build, including dependencies, define a security-txt, the build fails.

To avoid this issue, library authors - including projects that *might* be used as a library by others in the future - should exclude the `security_txt` macro during `no-entrypoint` builds.

Feel free to read up on the details in [the issue on the security-txt repository](https://github.com/neodyme-labs/solana-security-txt/issues/11).

The [official usage guide](https://github.com/neodyme-labs/solana-security-txt#usage) has also been updated. This PR includes the recommended changes.
